### PR TITLE
AJAX requests no longer trigger TOS middleware, fix JS build issues

### DIFF
--- a/assets/js/tests/spec/InboxSpec.js
+++ b/assets/js/tests/spec/InboxSpec.js
@@ -652,7 +652,7 @@ describe("Inbox", function() {
             });
         });
 
-        describe("Messages & Controller >", function(argument) {
+        describe("Messages & Controller >", function() {
 
             /*
 

--- a/connect/settings/authentication_settings.py
+++ b/connect/settings/authentication_settings.py
@@ -7,7 +7,8 @@ import environ
 env = environ.Env(
     DEFAULT_AUTH_BACKEND=(str, 'social.backends.ngpvan.ActionIDOpenID'),
     POST_LOGOUT_PAGE=(str, '/'),
-    SOCIAL_AUTH_NEW_USER_REDIRECT_URL=(str, '/explore/'),
+    SOCIAL_AUTH_NEW_USER_REDIRECT_URL=(
+        str, '/accounts/accept-terms/?next=/explore/'),
     LOGIN_REDIRECT_URL=(str, '/messages/'),
     LOGIN_ERROR_URL=(str, '/'),
     SOCIAL_AUTH_PROTECTED_FIELDS=(list, 'username'),

--- a/open_connect/middleware/accept_terms.py
+++ b/open_connect/middleware/accept_terms.py
@@ -18,7 +18,7 @@ class AcceptTermsAndConductMiddleware(object):
         """Process request and ask for an invite code if needed."""
         # Find users that are logged in but haven't been verified
         user = request.user
-        if user.is_authenticated():
+        if user.is_authenticated() and not request.is_ajax():
             if user.tos_accepted_at and user.ucoc_accepted_at:
                 return
             path = request.path_info.lstrip('/')

--- a/open_connect/middleware/tests/test_accept_terms.py
+++ b/open_connect/middleware/tests/test_accept_terms.py
@@ -59,3 +59,21 @@ class TestAcceptTermsAndConductMiddleware(TestCase):
             self.mw.process_request(request)['Location'],
             '{url}?next=/inbox/'.format(url=reverse('accept_terms_and_conduct'))
         )
+
+    def test_ajax_request_does_not_check_tos(self):
+        """If the request is an AJAX one, don't redirect to the TOS page."""
+        user = mommy.make(
+            'accounts.User', tos_accepted_at=now(), ucoc_accepted_at=None)
+        request = self.factory.get('/inbox/')
+        request.user = user
+        self.assertFalse(request.is_ajax())
+        self.assertEqual(
+            self.mw.process_request(request)['Location'],
+            '{url}?next=/inbox/'.format(url=reverse('accept_terms_and_conduct'))
+        )
+
+        ajax_request = self.factory.get(
+            '/inbox/', HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        ajax_request.user = user
+        self.assertTrue(ajax_request.is_ajax())
+        self.assertIsNone(self.mw.process_request(ajax_request))

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-hogan": "0.3.0",
     "load-grunt-config": "0.17.2",
-    "load-grunt-tasks": "3.2.0"
+    "load-grunt-tasks": "3.2.0",
+    "es5-shim": "^4.0.6"
   }
 }


### PR DESCRIPTION
Users who joined and went to the explore page were not being challenged to accept the TOS, but when they attempted to join a group the AJAX POST request was triggering the TOS redirect.

In this case we simply don't do the TOS challenge.

Also, the default post-signup page is now the "Accept the Terms of Service" page.

This also fixes some javascript test issues that were [preventing builds from passing](https://travis-ci.org/ofa/connect/builds/95105003).
@meaganoff can you take a look at those javascript changes? I'm going to merge this in, but let me know if this is something we need to take a longer look at.

Closes #8 