### PR TITLE
Update login_required middleware

### DIFF
--- a/open_connect/middleware/login_required.py
+++ b/open_connect/middleware/login_required.py
@@ -2,9 +2,11 @@
 # pylint: disable=no-self-use
 
 import re
+import json
 
 from django.conf import settings
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponseBadRequest
+from django.views.decorators.cache import patch_cache_control
 
 
 EXEMPT_URLS = [re.compile(settings.LOGIN_URL.lstrip('/'))]
@@ -30,6 +32,30 @@ class LoginRequiredMiddleware(object):
             if path == '':
                 return
             if not any(m.match(path) for m in EXEMPT_URLS):
-                redirect_to = '%s?next=%s' % (settings.LOGIN_URL,
-                                              request.path_info)
-                return HttpResponseRedirect(redirect_to)
+                if request.is_ajax():
+                    # For AJAX requests, return a 400 (which will trigger
+                    # jquery's ajax error functionality) and include the error
+                    # in a way consistent with the rest of Connect. This is to
+                    # prevent AJAX requests from ever being sent through the
+                    # login flow (which can cause problems.)
+                    response = HttpResponseBadRequest(
+                        json.dumps({
+                            'success': False,
+                            'errors': [
+                                'You Must Be Logged In',
+                            ]
+                        }),
+                        content_type='application/json'
+                    )
+                else:
+                    redirect_to = '%s?next=%s' % (settings.LOGIN_URL,
+                                                  request.path_info)
+                    response = HttpResponseRedirect(redirect_to)
+
+                # Break the client-side cache on all possible browsers on all
+                # protocols.
+                patch_cache_control(
+                    response, no_cache=True, no_store=True,
+                    must_revalidate=True, max_age=0, private=True,
+                    proxy_revalidate=True, s_maxage=0)
+                return response

--- a/open_connect/middleware/tests/test_login_required.py
+++ b/open_connect/middleware/tests/test_login_required.py
@@ -1,57 +1,108 @@
 """Tests for login_required middleware."""
 # pylint: disable=invalid-name
+import json
+import re
+
+from mock import patch
+
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import Client
 
-from django.contrib.auth import get_user_model
+from open_connect.connect_core.utils.basetests import ConnectTestMixin
 
 
-USER_MODEL = get_user_model()
-
-
-class LoginRequiredMiddlewareTest(TestCase):
+class LoginRequiredMiddlewareTest(ConnectTestMixin, TestCase):
     """Tests for login_required middleware."""
-    def setUp(self):
-        """Setup the LoginRequiredMiddlewareTest TestCase"""
-        self.user = USER_MODEL.objects.create_superuser(
-            'test@razzmatazz.local', 'greentea')
 
-    def test_login(self):
-        """Assert that a user can login."""
-        self.assertTrue(
-            self.client.login(
-                username='test@razzmatazz.local', password='greentea'))
+    @override_settings(LOGIN_URL='http://domain.example/login/backend/')
+    def test_redirect(self):
+        """Test that unauthenticated requests redirect to login flow"""
+        unauthenticated_client = Client()
 
-    def test_login_required(self):
-        """Test that login is required for different kinds of requests."""
-        def check_url(url_data):
-            """Check a url and assert that it provides the correct response."""
-            open_func = getattr(self.client, url_data.get('method', 'get'))
-            if 'args' in url_data:
-                response = open_func(reverse(url_data['url'],
-                                             args=url_data.get('args')))
-            elif 'kwargs' in url_data:
-                response = open_func(reverse(url_data['url'],
-                                             kwargs=url_data.get('kwargs')))
-            else:
-                response = open_func(reverse(url_data['url']))
-            self.assertEqual(
-                response.status_code, 302, 'URL: %s' % url_data['url'])
-
-        urllist = [
-            {'url': 'create_message'},
-            {'url': 'thread_details_json', 'kwargs': {'pk': 1}},
-            {'url': 'messages'},
-            {'url': 'update_subscriptions', 'method': 'post'},
-            {'url': 'user_profile'},
+        mock_exempt_urls = [
+            re.compile(r'^$'),
         ]
-        for url in urllist:
-            yield check_url, url
+        with patch(
+            'open_connect.middleware.login_required.EXEMPT_URLS',
+            mock_exempt_urls):
+
+            response = unauthenticated_client.get('/abcd/123/test')
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(
+                'http://domain.example/login/backend/?next=/abcd/123/test',
+                response.url)
+
+    @override_settings(LOGIN_URL='http://domain.example/login/backend/')
+    def test_exempt_url(self):
+        """Test the Exempt-URL Regex"""
+        unauthenticated_client = Client()
+
+        # There is no trivial way to mock the `LOGIN_EXEMPT_URL` setting here,
+        # so we'll need to ovverride the calculated result of the setting and
+        # patch that.
+        mock_exempt_urls = [
+            re.compile(r'^test1/wildcard/*'),
+            re.compile(r'^test2/absolute/$')
+        ]
+        with patch(
+            'open_connect.middleware.login_required.EXEMPT_URLS',
+            mock_exempt_urls):
+
+            # Test a wildcard regex exempt url. This will return a 404 instead
+            # of redirect to the login flow
+            valid_wildcard = unauthenticated_client.get('/test1/wildcard/a')
+            self.assertEqual(valid_wildcard.status_code, 404)
+
+            # Test an absolute regex exempt url. This will also return a 404
+            valid_absolute = unauthenticated_client.get('/test2/absolute/')
+            self.assertEqual(valid_absolute.status_code, 404)
+
+            # Test a URL that is not exempt. This will 302 through the login
+            # flow.
+            unexempt_url = unauthenticated_client.get('/test3/not_exempt')
+            self.assertEqual(unexempt_url.status_code, 302)
+            self.assertEqual(
+                'http://domain.example/login/backend/?next=/test3/not_exempt',
+                unexempt_url.url)
+
+    def test_ajax_request(self):
+        """Test an unauthented AJAX request to search for a 400"""
+        client = Client()
+        response = client.get(
+            reverse('create_message'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        self.assertEqual(response.status_code, 400)
+
+        response_data = json.loads(response.content)
+        self.assertDictItemsEqualUnordered(
+            response_data,
+            {
+                'success': False,
+                'errors': [
+                    'You Must Be Logged In'
+                ]
+            }
+        )
+
+    def test_no_cache_header(self):
+        """Test that responses contain all the relevant no-cache headers"""
+        client = Client()
+        response = client.get(reverse('create_message'))
+        self.assertEqual(response.status_code, 302)
+
+        self.assertIn('proxy-revalidate', response['Cache-Control'])
+        self.assertIn('no-store', response['Cache-Control'])
+        self.assertIn('private', response['Cache-Control'])
+        self.assertIn('max-age=0', response['Cache-Control'])
+        self.assertIn('no-cache', response['Cache-Control'])
+        self.assertIn('must-revalidate', response['Cache-Control'])
+        self.assertIn('s-maxage=0', response['Cache-Control'])
 
     def test_root_is_not_required(self):
         """Root of the application should be valid."""
         client = Client()
         response = client.get('/')
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.templates[0].name, 'welcome.html')


### PR DESCRIPTION
Currently AJAX requests were being sent through the login flow, which
could cause problems if you had multiple windows open and active AJAX
requests going.

For example, if you had one window open which was checking for new
messages and you logged out in another window, the next check for new
messages would attempt to go through the login flow. As the login flow
keeps track of the URL you're attempting to access when you first start
the flow it's possible that you could end up being redirected to the
check-for-new-messages JSON endpoint instead of an actual HTTP page.

This also adds no-cache headers to non-logged-in sessions. The headers
added should cover almost all cases of client-side caching on all
browsers.

This also cleans up the tests for the middleware quite a bit. As this
code predates some of the more modern testing mixins that are included
with Connect, this was an opportunity to use some of those to make the
tests slightly less likely to cause problems later as we change Connect.