### PR TITLE
Updating the travis post-test pylint flow

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -38,7 +38,7 @@ load-plugins=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=too-many-public-methods,too-few-public-methods,no-member,super-on-old-class,too-many-ancestors,I0011,deprecated-disable-all,file-ignored,maybe-no-member,unused-argument,star-args,no-init
+disable=too-many-public-methods,too-few-public-methods,no-member,super-on-old-class,too-many-ancestors,I0011,deprecated-disable-all,file-ignored,maybe-no-member,unused-argument,star-args,no-init,import-error
 
 
 [REPORTS]

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,8 @@ script:
   - grunt jasmine
 # install and run pylint if everything passed
 after_success:
-  - pip install pylint==1.4.4
-  - pylint --rcfile=$HOME/.pylintrc connect_extras open_connect connect
+  - pip install pylint==1.5.2
+  - pylint --rcfile=.pylintrc connect_extras open_connect connect
 # turn off email notifications
 notifications:
   email: false


### PR DESCRIPTION
We were incorrectly generating the `pylint` command previously in a
manor that the `.pylintrc` was not being used as a guideline for
testing. This changes the travis file, and also updates the pylint file