### PR TITLE
MIGRATION INVOLVED: Optimize database for notification tasks

### DIFF
--- a/open_connect/connectmessages/tasks.py
+++ b/open_connect/connectmessages/tasks.py
@@ -144,8 +144,7 @@ def send_system_message(recipient, subject, message_content):
     # plaintext email version of the message
     notification, created = Notification.objects.get_or_create(
         recipient_id=recipient.pk,
-        message=message,
-        triggered_at=message.created_at
+        message=message
     )
 
     if created and recipient.group_notification_period == 'immediate':

--- a/open_connect/notifications/migrations/0003_add_consumed_bool.py
+++ b/open_connect/notifications/migrations/0003_add_consumed_bool.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notifications', '0002_add_foreign_keys'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='notification',
+            name='consumed',
+
+            # The actual default is `False`, but if we set the default here
+            # to `True` we can avoid a heavy full-table UPDATE() in the next
+            # migration to reflect that most notifications have already been
+            # consumed.
+            field=models.BooleanField(default=True)
+        ),
+
+    ]

--- a/open_connect/notifications/migrations/0004_set_consumed.py
+++ b/open_connect/notifications/migrations/0004_set_consumed.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.utils.timezone import now
+
+
+def create_consumed(apps, schema_editor):
+    """Create a default category"""
+    Notification = apps.get_model("notifications", "Notification")
+    Notification.objects.filter(
+        consumed_at__isnull=True,
+        queued_at__isnull=True).exclude(
+        message__status='deleted').update(consumed=False)
+
+
+def tear_down_consumed(apps, schema_editor):
+    """
+    Go backwards if the consumed field is to be removed
+
+    By default mark every field as if it was consumed.
+    """
+    Notification = apps.get_model("notifications", "Notification")
+    Notification.objects.update(consumed_at=now(), queued_at=now(), triggered_at=now())
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notifications', '0003_add_consumed_bool'),
+    ]
+
+    operations = [
+        # If forwards create a default consumption. If backwards don't do
+        # anything and let the previous migration simply drop the column
+        migrations.RunPython(create_consumed, tear_down_consumed),
+    ]

--- a/open_connect/notifications/migrations/0005_remove_queued_datetimes.py
+++ b/open_connect/notifications/migrations/0005_remove_queued_datetimes.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notifications', '0004_set_consumed'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='notification',
+            name='consumed_at',
+        ),
+        migrations.RemoveField(
+            model_name='notification',
+            name='queued_at',
+        ),
+        migrations.RemoveField(
+            model_name='notification',
+            name='triggered_at',
+        ),
+    ]

--- a/open_connect/notifications/migrations/0006_add_indexes.py
+++ b/open_connect/notifications/migrations/0006_add_indexes.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notifications', '0005_remove_queued_datetimes'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='notification',
+            name='consumed',
+            field=models.BooleanField(default=False, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='subscription',
+            name='period',
+            field=models.CharField(default=b'immediate', max_length=30, db_index=True, choices=[(b'none', b"Don't send email notifications"), (b'daily', b'Send a daily digest'), (b'immediate', b'Send me an email for every new message')]),
+        ),
+    ]

--- a/open_connect/notifications/models.py
+++ b/open_connect/notifications/models.py
@@ -18,7 +18,8 @@ class Subscription(TimestampModel):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, related_name='subscriptions')
     period = models.CharField(
-        max_length=30, choices=NOTIFICATION_PERIODS, default='immediate')
+        max_length=30, choices=NOTIFICATION_PERIODS, default='immediate',
+        db_index=True)
     group = models.ForeignKey('groups.Group')
 
     class Meta(object):
@@ -60,9 +61,7 @@ class Subscription(TimestampModel):
 class Notification(TimestampModel):
     """Information about an individual notification."""
     recipient = models.ForeignKey(settings.AUTH_USER_MODEL)
-    triggered_at = models.DateTimeField(blank=True, null=True)
-    queued_at = models.DateTimeField(blank=True, null=True)
-    consumed_at = models.DateTimeField(blank=True, null=True)
+    consumed = models.BooleanField(default=False, db_index=True)
     subscription = models.ForeignKey(Subscription, blank=True, null=True)
     message = models.ForeignKey('connectmessages.Message')
 

--- a/open_connect/notifications/tests/test_utils.py
+++ b/open_connect/notifications/tests/test_utils.py
@@ -12,6 +12,9 @@ class FakeModel(models.Model):
     """Fake model for testing."""
     somefield = models.TextField()
 
+    class Meta(object):
+        managed = False
+
 
 @patch.object(utils.models, 'get_models')
 class GetNotificationModelsTest(TestCase):


### PR DESCRIPTION
Due to the pure number of notifications that Connect sends out, the
notification table gets quite large. This means that comparisons that
rely on character fields being null, unnecessary date fields, and other
intense queries will choke. Especially during bulk tasks, such as during
nightly notification sends.

This update streamlines the daily digest process considerably, by
changing what fields are included in the notification table and adding
much needed indexes.

This push involves a sizable migration for very large tables.