### PR TITLE
Allow group owners to edit own groups

### DIFF
--- a/open_connect/accounts/views.py
+++ b/open_connect/accounts/views.py
@@ -193,6 +193,8 @@ class UpdateUserPermissionView(
         ('groups', 'add_group'),
         ('groups', 'change_group'),
         ('groups', 'can_edit_any_group'),
+        ('groups', 'can_edit_group_category'),
+        ('groups', 'can_edit_group_featured'),
         ('resources', 'add_resource'),
         ('resources', 'can_add_resource_anywhere')
     )

--- a/open_connect/groups/forms.py
+++ b/open_connect/groups/forms.py
@@ -39,8 +39,6 @@ class GroupImageForm(forms.ModelForm):
 
 class GroupForm(SanitizeHTMLMixin, ModelForm):
     """Form for groups.models.Group."""
-    category = forms.ModelChoiceField(
-        label='Category', queryset=Category.objects.all())
     tags = TaggitField(
         widget=TaggitWidget(
             'TagAutocomplete', attrs={'placeholder': "type tags here"}),

--- a/open_connect/groups/migrations/0004_add_change_group_permissions.py
+++ b/open_connect/groups/migrations/0004_add_change_group_permissions.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('groups', '0003_add_foreign_keys'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='group',
+            options={'ordering': ['-featured', '-is_national', 'group__name'], 'permissions': (('can_edit_any_group', 'Can edit any group.'), ('can_edit_group_category', "Can change a group's category."), ('can_edit_group_featured', "Can change a group's featured status."))},
+        ),
+    ]

--- a/open_connect/groups/models.py
+++ b/open_connect/groups/models.py
@@ -202,6 +202,9 @@ class Group(TimestampModel):
         ordering = ['-featured', '-is_national', 'group__name']
         permissions = (
             ('can_edit_any_group', 'Can edit any group.'),
+            ('can_edit_group_category', 'Can change a group\'s category.'),
+            ('can_edit_group_featured',
+             'Can change a group\'s featured status.'),
         )
 
     def __unicode__(self):

--- a/open_connect/groups/templates/groups/group_detail.html
+++ b/open_connect/groups/templates/groups/group_detail.html
@@ -20,10 +20,8 @@
 
         <div class="member-status admin">
             <div class="member-status-block">ADMIN</div>
-            {% if perms.groups.change_group %}
-                <a href="{% url "update_group" group.pk %}" class="btn-primary btn btn-block hidden-xs">Edit Group</a>
-                <a href="{% url "update_group" group.pk %}" class="visible-xs-block">Edit Group</a>
-            {% endif %}
+            <a href="{% url "update_group" group.pk %}" class="btn-primary btn btn-block hidden-xs">Edit Group</a>
+            <a href="{% url "update_group" group.pk %}" class="visible-xs-block">Edit Group</a>
         </div>
         {% else %} {% if group not in user.groups_joined %}
         <!-- {% if group.id in requested_ids %}


### PR DESCRIPTION
This change allows group owners to change information about their group. However, the ability to make a group "Featured" or not, or change the category, is restricted to users who have the permission to do so.

This usually means superusers, but not always.