### PR TITLE
Remove banned & flagged messages from unmoderated list

### DIFF
--- a/open_connect/groups/models.py
+++ b/open_connect/groups/models.py
@@ -274,7 +274,9 @@ class Group(TimestampModel):
         Return all unmoderated messages
         """
         return Message.objects.filter(
-            thread__group=self, status='pending')
+            thread__group=self,
+            status__in=['pending', 'flagged'],
+            sender__is_banned=False)
 
     @property
     def total_unmoderated_messages(self):


### PR DESCRIPTION
There was a problem with the message moderation pane showing messages from banned users as part of the total number of unmoderated messages. This fixes that