### PR TITLE
Improve security with Mozilla's `bleach`

### DIFF
--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -36,6 +36,7 @@ simplejson==3.7.1
 tablib==0.10.0
 ua-parser==0.3.6
 unidecode==0.04.17
+-e git+https://github.com/mozilla/bleach.git@b18f4273bad796734ce37b1048b266730bae2dd3#egg=bleach
 
 
 # AWS Specific Packages

--- a/open_connect/connect_core/tests/test_utils_mixins.py
+++ b/open_connect/connect_core/tests/test_utils_mixins.py
@@ -52,6 +52,28 @@ TEST_HTML = u'''
     Multiple Lines
     <img src="http://localhost/fantastic.jpg" data-embed="cool_embed">
     <img src="http://localhost/big.jpg" style="display: none;">
+
+    <!-- Emoji -->
+    😍<br>
+    👩🏽<br>
+    👾 🙇 💁 🙅 🙆 🙋 🙎 🙍 <br>
+    🐵 🙈 🙉 🙊<br>
+    ❤️ 💔 💌 💕 💞 💓 💗 💖 💘 💝 💟 💜 💛 💚 💙<br>
+    ✋🏿 💪🏿 👐🏿 🙌🏿 👏🏿 🙏🏿<br>
+    🚾 🆒 🆓 🆕 🆖 🆗 🆙 🏧<br>
+    0️⃣ 1️⃣ 2️⃣ 3️⃣ 4️⃣ 5️⃣ 6️⃣ 7️⃣ 8️⃣ 9️⃣ 🔟<br>
+    🇺🇸🇦<br>
+
+    <!-- Japanese Emoticons -->
+    (╯°□°）╯︵ ┻━┻)<br>
+    ヽ༼ຈل͜ຈ༽ﾉ ヽ༼ຈل͜ຈ༽ﾉ<br>
+
+    <!-- Two-Byte Characters -->
+    田中さんにあげて下さい<br>
+    パーティーへ行かないか<br>
+    和製漢語<br>
+    部落格<br>
+
     <!-- vars:redactor=true -->
 '''
 
@@ -516,6 +538,9 @@ class SanitizeHTMLMixinTest(TestCase):
 
         # Test Unicode
         self.assertTrue(u'Ⴚ'.encode("utf-8") in safe_html)
+        self.assertTrue(u'🙉'.encode("utf-8") in safe_html)
+        self.assertTrue(u'語'.encode("utf-8") in safe_html)
+        self.assertTrue(u'╯°□°）╯︵ ┻━┻'.encode("utf-8") in safe_html)
 
         # Test src attribute with a valid domain
         self.assertTrue('localhost' in safe_html)

--- a/open_connect/connect_core/tests/test_utils_mixins.py
+++ b/open_connect/connect_core/tests/test_utils_mixins.py
@@ -568,4 +568,4 @@ class SanitizeHTMLMixinTest(TestCase):
 
         result = self.mixin.sanitize_html(message)
         self.assertEqual(
-            result, 'Line 1 Line 3 Line 7 <!-- vars:redactor=true -->')
+            result, 'Line 1 Line 3 Line 7')

--- a/open_connect/connect_core/tests/test_utils_mixins.py
+++ b/open_connect/connect_core/tests/test_utils_mixins.py
@@ -53,6 +53,15 @@ TEST_HTML = u'''
     <img src="http://localhost/fantastic.jpg" data-embed="cool_embed">
     <img src="http://localhost/big.jpg" style="display: none;">
 
+    <!-- Dangerous Strings -->
+    <a href="\x02javascript:javascript:alert(1)" id="fuzzelement1">test</a><br>
+    ABC<div style="x:\xE2\x80\x81expression(javascript:alert(1)">DEF<br>
+    &lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;<br>
+    <SCRIPT/XSS SRC="http://ha.ckers.org/xss.js"></SCRIPT><br>
+    <IMG onmouseover="alert('xxs')"><br>
+    <a oncopy=alert()>Copy me</a><br>
+    <IMG SRC="jav   ascript:alert('XSS');"><br>
+
     <!-- Emoji -->
     😍<br>
     👩🏽<br>
@@ -526,10 +535,14 @@ class SanitizeHTMLMixinTest(TestCase):
 
         # Test Unacceptable HTML
         self.assertFalse('iframe' in safe_html)
-        self.assertFalse('<script>' in safe_html)
+        self.assertFalse('<script' in safe_html)
         self.assertFalse('h1' in safe_html)
         self.assertFalse('div' in safe_html)
         self.assertFalse('alt=' in safe_html)
+        self.assertFalse('javascript' in safe_html)
+        self.assertFalse('onmouseover' in safe_html)
+        self.assertFalse('oncopy' in safe_html)
+        self.assertFalse('XSS' in safe_html)
 
         # Test Unacceptable Attributes
         self.assertFalse('display: none;' in safe_html)


### PR DESCRIPTION
Mozilla's `bleach` library will filter obscure tags introduced into messages by nefarious users who wish to do things like run scripts or insert bad images.

We have to use the github repository instead of the python package index in our `common-requirements.txt` file because it doesn't appear that the latest version of bleach actually exists on pypi.

@jbouvier let me know if I'm missing anything