### PR TITLE
Allow granting of permission to email invites

### DIFF
--- a/common-requirements.txt
+++ b/common-requirements.txt
@@ -18,7 +18,9 @@ newrelic==2.68.0.50
 # Core Requirements
 beautifulsoup4==4.3.2
 django-autocomplete-light==2.1.1
-django-celery==3.1.16
+django-celery==3.1.17
+celery==3.1.23
+kombu==3.0.37
 django-extra-views==0.6.5
 django-ipware==1.0.0
 django-pure-pagination==0.2.1

--- a/open_connect/accounts/views.py
+++ b/open_connect/accounts/views.py
@@ -179,6 +179,7 @@ class UpdateUserPermissionView(
     # ('app_label', 'permission_codename')
     editable_permissions = (
         ('accounts', 'add_invite'),
+        ('accounts', 'email_invites'),
         ('accounts', 'can_unban'),
         ('accounts', 'can_ban'),
         ('accounts', 'can_view_banned'),


### PR DESCRIPTION
It is not currently possible for non-superusers to create invites that send out emails. This commit will expose that permission on the "Update Permissions" account management page.