### PR TITLE
Signals receivers was not initialize

### DIFF
--- a/private_connect/__init__.py
+++ b/private_connect/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'private_connect.apps.LocalConnectConfig'


### PR DESCRIPTION
The signals is initialize when the function ready is called:

https://github.com/ofa/connect/blob/master/private_connect/apps.py#L14

But it was never called, after some debugs I found this doc

https://docs.djangoproject.com/en/1.8/ref/applications/

And saw a miss config on __init__.py

After put that config everything works
