### PR TITLE
Update domain references to ofa.us

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,6 @@ Connect is available under a MIT license for third parties to use and contribute
 For more information about using and configuring Connect visit the `Documentation`_.
 
 .. _Connect: https://ofa.github.io/
-.. _Organizing for Action: https://www.barackobama.com/
+.. _Organizing for Action: https://www.ofa.us/
 .. _Github repository: https://www.github.com/ofa/connect
 .. _Documentation: https://opendocs.ofaconnect.com/

--- a/docs/contribution/index.rst
+++ b/docs/contribution/index.rst
@@ -35,7 +35,7 @@ Before code can be accepted by Organizing for Action for inclusion in our projec
 
 Individuals should sign the `Individual Contributor License Agreement`_ and if your work was done as part of your employment you will need to submit the `Entity Contributor License Agreement`_.
 
-There is also an `OFA Contributor License FAQ`_ which provides further details about contributing code. Further questions can be sent to `cla@barackobama.com <mailto:cla@barackobama.com>`_.
+There is also an `OFA Contributor License FAQ`_ which provides further details about contributing code. Further questions can be sent to `cla@ofa.us <mailto:cla@ofa.us>`_.
 
 
 .. _Individual Contributor License Agreement: https://ofa.github.io/cla-individual.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,5 +26,5 @@ use and contribute to. For more information about contributing view the
     /license
 
 .. _Connect: https://ofa.github.io/connect/
-.. _Organizing for Action: https://www.barackobama.com/
+.. _Organizing for Action: https://www.ofa.us/
 .. _Github repository: https://www.github.com/ofa/connect


### PR DESCRIPTION
Hello @lorn and @nickcatal,

This PR updates a few domain references to ofa.us. These changes will need to go into OFA's version of Connect as well.

Let me know if you have any questions.

Camden