### PR TITLE
Allow admins to change staff status of users

### DIFF
--- a/open_connect/accounts/forms.py
+++ b/open_connect/accounts/forms.py
@@ -39,7 +39,7 @@ class UserForm(SanitizeHTMLMixin, forms.ModelForm):
             'first_name', 'last_name', 'biography', 'timezone',
             'facebook_url', 'twitter_handle', 'website_url',
             'group_notification_period', 'show_groups_on_profile',
-            'receive_group_join_notifications'
+            'receive_group_join_notifications', 'is_staff'
         ]
 
     def clean_biography(self):

--- a/open_connect/accounts/migrations/0004_add_modify_staff_status_permission.py
+++ b/open_connect/accounts/migrations/0004_add_modify_staff_status_permission.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0003_create_system_user'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='user',
+            options={'verbose_name': 'user', 'verbose_name_plural': 'users', 'permissions': (('can_view_banned', 'Can view banned users.'), ('can_ban', 'Can ban users.'), ('can_unban', 'Can unban users.'), ('can_view_user_report', 'Can view user report.'), ('can_view_group_report', 'Can view group report.'), ('can_impersonate', 'Can impersonate other users.'), ('can_moderate_all_messages', 'Can moderate all messages.'), ('can_initiate_direct_messages', 'Can initiate direct messages.'), ('can_modify_permissions', 'Can modify user permissions.'), ('can_modify_staff_status', "Can modify a user's staff status"))},
+        ),
+    ]

--- a/open_connect/accounts/models.py
+++ b/open_connect/accounts/models.py
@@ -186,7 +186,8 @@ class User(
             ('can_impersonate', 'Can impersonate other users.'),
             ('can_moderate_all_messages', 'Can moderate all messages.'),
             ('can_initiate_direct_messages', 'Can initiate direct messages.'),
-            ('can_modify_permissions', 'Can modify user permissions.')
+            ('can_modify_permissions', 'Can modify user permissions.'),
+            ('can_modify_staff_status', "Can modify a user's staff status")
         )
 
     def get_absolute_url(self):

--- a/open_connect/accounts/views.py
+++ b/open_connect/accounts/views.py
@@ -144,6 +144,11 @@ class UserUpdateView(
         forms = super(UserUpdateView, self).get_forms(form_classes)
         if not self.object.groups_moderating.exists():
             del forms['user_form'].fields['receive_group_join_notifications']
+
+        # Only allow those with the permission to toggle staff status
+        if not self.request.user.has_perm('accounts.can_modify_staff_status'):
+            del forms['user_form'].fields['is_staff']
+
         return forms
 
     def form_valid(self, forms, all_cleaned_data):
@@ -188,6 +193,7 @@ class UpdateUserPermissionView(
         ('accounts', 'can_moderate_all_messages'),
         ('accounts', 'can_initiate_direct_messages'),
         ('accounts', 'change_user'),
+        ('accounts', 'can_modify_staff_status'),
         ('media', 'can_promote_image'),
         ('media', 'can_access_admin_gallery'),
         ('media', 'can_access_admin_gallery'),


### PR DESCRIPTION
Up to this point if you wanted to change the `Staff Member` status of an individual user you needed to go into the database or use the python shell. This code adds that ability to the "Update User" panel for admins who are explicitly given permission to update staff status.

Requires a migration