### PR TITLE
Hide banned user's replies

### DIFF
--- a/open_connect/connectmessages/models.py
+++ b/open_connect/connectmessages/models.py
@@ -629,6 +629,12 @@ class Message(TimestampModel):
         if self.sender == user:
             return True
 
+        # If the sender is banned, return False. Because this is located after
+        # the "Return True if message is from sender" this will allow us to
+        # "shadow ban" users.
+        if self.sender.is_banned == True:
+            return False
+
         if not self.thread.visible_to_user(user, self):
             return False
 


### PR DESCRIPTION
We currently do not hide replies that are sent from banned users from being viewed in the app. Since we want to retain our "shadow ban" functionality adding a test to the "is this message viewable by {user}" method that hides messages sent from banned users should address this issue.