### PR TITLE
(Re-)Add pagination to group member list page

### DIFF
--- a/connect/settings/application_settings.py
+++ b/connect/settings/application_settings.py
@@ -12,7 +12,8 @@ env = environ.Env(
     SYSTEM_USER_EMAIL=(str, 'connect@connect.local'),
     GOOGLE_ANALYTICS_PROPERTY_ID=(str, 'UA-0-0'),
     GOOGLE_ANALYTICS_DEBUG_MODE=(bool, False),
-    ICON_PREFIX=(str, "glyphicon glyphicon-")
+    ICON_PREFIX=(str, "glyphicon glyphicon-"),
+    GROUP_MEMBER_LIST_PAGINATION_SIZE=(int, 40)
 )
 
 
@@ -75,3 +76,6 @@ EMAIL_SECRET_KEY = env('EMAIL_SECRET_KEY')
 # Prefix to be appended to all icons. This allows you to use icons other than
 # glyphicons
 ICON_PREFIX = env('ICON_PREFIX')
+
+# Total number of group members to paginate by on the "Group Member List" page
+GROUP_MEMBER_LIST_PAGINATION_SIZE = env('GROUP_MEMBER_LIST_PAGINATION_SIZE')

--- a/docs/dev/settings.rst
+++ b/docs/dev/settings.rst
@@ -298,6 +298,13 @@ Connect offers you the ability to swap-out the standard `Glyphicon`_ library by 
 .. _Glyphicon: http://glyphicons.com/
 
 
+GROUP_MEMBER_LIST_PAGINATION_SIZE
+---------------------------------
+
+Default: ``40`` (Integer)
+
+When a group contains a large number of members the "List Members of the Group" page needs to be paginated to reduce the page size and limit the number of avatars displayed. You can override the default (40) by adjusting this setting.
+
 
 Base
 ====

--- a/open_connect/groups/templates/groups/group_member_list.html
+++ b/open_connect/groups/templates/groups/group_member_list.html
@@ -9,7 +9,7 @@
 {% block page_content %}
     <h4 class="{{group.category.slug}}"> <a href="{% url "group_details" group.pk %}">{{group}}</a></h4>
     <h1>
-        <span class="count">{{ group_members.count }}</span> member{{ group_members.count|pluralize }}
+        <span class="count">{{ total_members }}</span> member{{ total_members|pluralize }}
         <form class="form-search form" role="form">
                 <input name="q" type="text" class="form-control search-query" value="{{ q|default:"" }}">
                 <button class="btn btn-link btn-search" type="submit"><i class="{{icon_prefix}}search"></i></button>

--- a/open_connect/groups/tests/test_views.py
+++ b/open_connect/groups/tests/test_views.py
@@ -1013,6 +1013,23 @@ class GroupMemberListViewTest(ConnectTestMixin, DjangoTestCase):
         self.assertIn(owner, response.context['group_owners'])
         self.assertNotIn(member, response.context['group_owners'])
 
+    def test_group_member_count(self):
+        """Test that the context contains the total number of members"""
+        group = self.create_group()
+        member1 = self.create_user()
+        member2 = self.create_user()
+        member3 = self.create_user()
+
+        member1.add_to_group(group.pk)
+        member2.add_to_group(group.pk)
+        member3.add_to_group(group.pk)
+
+        self.login(member1)
+        response = self.client.get(
+            reverse('group_members', kwargs={'pk': group.pk}))
+
+        self.assertEqual(3, response.context['total_members'])
+
 
 class TestQuickAddUserToGroup(ConnectMessageTestCase):
     """Tests for group_quick_user_add."""

--- a/open_connect/groups/views.py
+++ b/open_connect/groups/views.py
@@ -372,6 +372,7 @@ class GroupMemberListView(PaginationMixin, ListView):
     model = get_user_model()
     template_name = 'groups/group_member_list.html'
     context_object_name = 'group_members'
+    paginate_by = 40
 
     def get_queryset(self):
         """Only get members of the current group.

--- a/open_connect/groups/views.py
+++ b/open_connect/groups/views.py
@@ -404,6 +404,7 @@ class GroupMemberListView(PaginationMixin, ListView):
         context = super(GroupMemberListView, self).get_context_data(**kwargs)
         group = get_object_or_404(Group, pk=self.kwargs.get('pk'))
         context['group'] = group
+        context['total_members'] = group.get_members().count()
         context['q'] = self.request.GET.get('q', '')
         context['user_is_owner'] = self.request.user.groups_moderating.filter(
             pk=self.kwargs.get('pk'))

--- a/open_connect/groups/views.py
+++ b/open_connect/groups/views.py
@@ -409,7 +409,8 @@ class GroupMemberListView(PaginationMixin, ListView):
         context['q'] = self.request.GET.get('q', '')
         context['user_is_owner'] = self.request.user.groups_moderating.filter(
             pk=self.kwargs.get('pk'))
-        context['group_owners'] = group.owners.all().order_by('first_name')
+        context['group_owners'] = group.owners.all().select_related(
+            'image').order_by('first_name')
         return context
 
 

--- a/open_connect/groups/views.py
+++ b/open_connect/groups/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
+from django.conf import settings
 from django.db.models import Q
 from django.http import HttpResponse, Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
@@ -372,7 +373,7 @@ class GroupMemberListView(PaginationMixin, ListView):
     model = get_user_model()
     template_name = 'groups/group_member_list.html'
     context_object_name = 'group_members'
-    paginate_by = 40
+    paginate_by = settings.GROUP_MEMBER_LIST_PAGINATION_SIZE
 
     def get_queryset(self):
         """Only get members of the current group.

--- a/open_connect/groups/views.py
+++ b/open_connect/groups/views.py
@@ -385,10 +385,8 @@ class GroupMemberListView(PaginationMixin, ListView):
         if (group.member_list_published
                 or user.is_superuser
                 or group.owners.filter(pk=user.pk).exists()):
-            queryset = super(GroupMemberListView, self).get_queryset().filter(
-                groups__group=group
-            ).exclude(
-                pk__in=group.owners.all().only('pk')).order_by('first_name')
+            queryset = group.get_members_avatar_prioritized().exclude(
+                pk__in=group.owners.all().only('pk'))
             if self.request.GET.get('q'):
                 query = self.request.GET['q']
                 queryset = queryset.filter(


### PR DESCRIPTION
The Django Pure Pagination mixin is enabled for the group member list page, but it doesn't appear that the `paginate_by` property was removed at some point in the past few years. Adding that back and setting the property to list 40 members, which means most groups should see most if not all of their member list on one page while still keeping things performant for groups with thousands of members.