### PR TITLE
Remove django group from the django admin

### DIFF
--- a/open_connect/groups/admin.py
+++ b/open_connect/groups/admin.py
@@ -1,5 +1,6 @@
 """Admin functionality for group app"""
 from django.contrib import admin
+from django.contrib.auth.models import Group as AuthGroup
 
 from open_connect.groups.models import Category
 
@@ -12,3 +13,8 @@ class CategoryAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Category, CategoryAdmin)
+
+
+# Remove AuthGroup from the admin to prevent admins from being able to assign
+# permissions to groups or otherwise edit groups in the admin.
+admin.site.unregister(AuthGroup)


### PR DESCRIPTION
Because by default the django admin will let you edit the permissions of django groups, and it's possible to impersonate someone with rights to the group admin, if we want to limit privilege escalation we need to make the only place you can change a user's permissions the "Update User Permissions" view included in the Connect accounts app.

This can be accomplished by de-registering the admin for groups.