### PR TITLE
Change the batch size of UserThread creation

### DIFF
--- a/open_connect/connectmessages/tasks.py
+++ b/open_connect/connectmessages/tasks.py
@@ -98,8 +98,9 @@ def send_message(message_id, shorten=True):
             ]
 
         if userthreads:
-            # Let django batch-insert all the new userthreads
-            UserThread.objects.bulk_create(userthreads)
+            # Let django batch-insert all the new userthreads. Insert in
+            # batches of 250
+            UserThread.objects.bulk_create(userthreads, batch_size=250)
     else:
         UserThread.objects.filter(
             thread=thread, read=True).exclude(user=sender).update(read=False)


### PR DESCRIPTION
When a message is sent a worker creates 1 record in a many-to-many through table (the UserThread table) for every member in the group eligible to receive that message. Previously this would be done in one very large INSERT query. Creating 3000+ rows in 1 table that is actively being read from by users in 1 query is a bit intensive on the database and was sometimes failing to create all the records. By changing things so that these inserts are done in batches of 250 we increase the number of queries involved in sending a message but potentially reduce the load on the popular UserThread table.