### PR TITLE
Use the database to create UserThread objects

### DIFF
--- a/open_connect/connectmessages/tests/test_models.py
+++ b/open_connect/connectmessages/tests/test_models.py
@@ -438,11 +438,15 @@ class MessageShortenTest(ConnectTestMixin, TestCase):
     """Tests for shortening links in a message."""
     def test_links_in_message_are_shortened(self):
         """Links in a message should be replaced with short code."""
-        thread = mommy.make(Thread)
+        sender = self.create_user()
+        group = self.create_group()
+        sender.add_to_group(group.pk)
+
+        thread = mommy.make(Thread, group=group)
         message = Message(
             text='This is a <a href="http://www.razzmatazz.local">link</a>',
             thread=thread,
-            sender=self.create_user()
+            sender=sender
         )
         message.save()
         self.assertEqual(message.links.count(), 1)
@@ -450,11 +454,15 @@ class MessageShortenTest(ConnectTestMixin, TestCase):
 
     def test_links_in_message_are_not_shortened(self):
         """If shorten=False, links in message should not be replaced."""
-        thread = mommy.make(Thread)
+        sender = self.create_user()
+        group = self.create_group()
+        sender.add_to_group(group.pk)
+
+        thread = mommy.make(Thread, group=group)
         message = Message(
             text='This is a <a href="http://www.razzmatazz.local">link</a>',
             thread=thread,
-            sender=self.create_user()
+            sender=sender
         )
         message.save(shorten=False)
         self.assertEqual(message.links.count(), 0)
@@ -476,11 +484,15 @@ class MessageShortenTest(ConnectTestMixin, TestCase):
 
     def test_non_http_links_not_shortened(self):
         """Non http/s links shouldn't be shortened."""
-        thread = mommy.make(Thread)
+        sender = self.create_user()
+        group = self.create_group()
+        sender.add_to_group(group.pk)
+
+        thread = mommy.make(Thread, group=group)
         message = Message(
             text='This is an email: <a href="mailto:a@b.local">lnk</a>',
             thread=thread,
-            sender=self.create_user()
+            sender=sender
         )
         message.save()
         self.assertEqual(message.links.count(), 0)
@@ -627,7 +639,7 @@ class TestMessagesForUser(ConnectMessageTestCase):
         self.user.add_to_group(group.pk)
         self.sender = mommy.make(USER_MODEL, is_superuser=True)
         self.thread = mommy.make(
-            'connectmessages.Thread', recipients=[self.user])
+            'connectmessages.Thread', recipients=[self.user], group=group)
 
     def test_get_message_new(self):
         """New message should not be marked as read."""

--- a/open_connect/groups/tests/test_models.py
+++ b/open_connect/groups/tests/test_models.py
@@ -441,9 +441,8 @@ class GroupImagesTest(ConnectTestMixin, TestCase):
     def get_images_message(self, group, images=None):
         """Make a message that has the images in the specified group."""
         # Create a message
-        thread = mommy.make('connectmessages.Thread')
-        message = mommy.make(
-            'connectmessages.Message', thread=thread, sender=self.superuser)
+        thread = self.create_thread(group=group, sender=self.superuser)
+        message = thread.first_message
 
         # Default images
         if not images:
@@ -453,15 +452,11 @@ class GroupImagesTest(ConnectTestMixin, TestCase):
         for image in images:
             message.images.add(image)
 
-        # Add message to group
-        message.thread.group = group
-        message.thread.save()
-
         return message
 
     def test_image_posted_to_group_present(self):
         """An image posted to the group should be present."""
-        group = mommy.make('groups.Group')
+        group = self.create_group()
         message = self.get_images_message(group)
         self.assertQuerysetEqual(
             group.images(user=message.sender).all(),
@@ -471,7 +466,7 @@ class GroupImagesTest(ConnectTestMixin, TestCase):
 
     def test_image_posted_to_another_group_not_present(self):
         """An image posted to another group should not be present."""
-        group = mommy.make('groups.Group')
+        group = self.create_group()
         other_group = mommy.make('groups.Group')
         message = self.get_images_message(other_group)
         for image in message.images.all():
@@ -482,8 +477,6 @@ class GroupLinksTest(ConnectTestMixin, TestCase):
     """Test the links method"""
     def setUp(self):
         """Setup the links test"""
-        super(GroupLinksTest, self).setUp()
-
         # Make a popular link and an unpopular link
         self.popular_link = ShortenedURL(url='http://something.com')
         self.popular_link.click_count = 10000
@@ -494,24 +487,16 @@ class GroupLinksTest(ConnectTestMixin, TestCase):
     def get_links_message(self, group, links=None):
         """Make a message that has the links in the specified group."""
         # Create a message
-        thread = mommy.make('connectmessages.Thread')
-        message = mommy.make(
-            'connectmessages.Message',
-            thread=thread,
-            sender=self.create_superuser()
-        )
+        thread = self.create_thread(group=group)
+        message = thread.first_message
 
-        # Default images
+        # Default links
         if not links:
             links = [self.popular_link, self.unpopular_link]
 
-        # Add images to message
+        # Add links to message
         for link in links:
             message.links.add(link)
-
-        # Add message to group
-        message.thread.group = group
-        message.thread.save()
 
         return message
 


### PR DESCRIPTION
In an attempt to reduce the number of queries against the database we can use a single SQL query to insert all the UserThread objects into the database for each group send. This should substantially speed up sending new threads to large groups.

@lorn let me know what you think